### PR TITLE
fix malformed json

### DIFF
--- a/aspects.bzl
+++ b/aspects.bzl
@@ -108,7 +108,7 @@ def _compilation_database_impl(ctx):
         compilation_db += target[CompilationAspect].compilation_db
 
     content = "[\n" + _compilation_db_json(compilation_db) + "\n]"
-    ctx.file_action(output=ctx.outputs.filename, content=_compilation_db_json(compilation_db))
+    ctx.file_action(output=ctx.outputs.filename, content=content)
 
 
 compilation_database = rule(


### PR DESCRIPTION
I believe that was a copy failure. The change ensures that the data is enclosed in an array '[ ]'.

Any comments and notes welcome.

Thank you so much for sharing this code, I love it as it's a huge step enabling broader IDE support for bazel.