### PR TITLE
set exec_root relative to project-root

### DIFF
--- a/aspects.bzl
+++ b/aspects.bzl
@@ -70,8 +70,7 @@ def _compilation_database_aspect_impl(target, ctx):
                        " -c " + src.short_path)
 
         # TODO: This exec_root hack does not work for external repos.
-        root = str(src.root).split("[")[0]
-        exec_root = root + "/bazel-" + root.split("/")[-1]
+        exec_root = "bazel-" + str(ctx.workspace_name)
         compilation_db.append(struct(directory=exec_root, command=commandline, file=src.short_path))
 
     # Write the commands for this target.

--- a/aspects.bzl
+++ b/aspects.bzl
@@ -108,7 +108,7 @@ def _compilation_database_impl(ctx):
         compilation_db += target[CompilationAspect].compilation_db
 
     content = "[\n" + _compilation_db_json(compilation_db) + "\n]"
-    ctx.file_action(output=ctx.outputs.filename, content=_compilation_db_json(compilation_db))
+    ctx.file_action(output=ctx.outputs.filename, content=content)
 
 
 compilation_database = rule(


### PR DESCRIPTION
Hi,

please see this PR as discussion base. I'm not sure if I understood the code fully.
This PR addresses a TODO in your code. I tried to get it to work with rtags (there is another PR open, https://github.com/Andersbakken/rtags/pull/1062).

In essence the problem was to get an absolute path to sources from within bazel to build the compile_commands.json (rtags requires absolute paths). I proposed a fix for rtags which allows relative paths in compile_commands.json which will be resolved to an absolute path by rc's --project-root argument.
With these changes in both repos, that worked for me. This PR just contains the change to provide a relative path to exec_root starting with project-root. However I'm not quite sure if that's the right way to go.

As you mentioned in the readme, you tested your bazel-compilation-database with rtags. Could you please give me some advise how you did that in detail? As outlined above I needed to change rtags and your rule to get this to work.

Maybe this change works for you as well. If so, feel free to merge.

Kind Regards
    Matzkowsky