### PR TITLE
use a marker for workspace_root (replacing exec_root)

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -53,7 +53,7 @@ echo "[" > "${COMPDB_FILE}"
 find "${EXEC_ROOT}" -name '*.compile_commands.json' -exec bash -c 'cat "$1" && echo ,' _ {} \; \
   >> "${COMPDB_FILE}"
 sed -i.bak -e '/^,$/d' -e '$s/,$//' "${COMPDB_FILE}"  # Hygiene to make valid json
-sed -i.bak -e "s|__EXEC_ROOT__|${EXEC_ROOT}|" "${COMPDB_FILE}"  # Replace exec_root marker
+sed -i.bak -e "s|__WORKSPACE_ROOT__|${WORKSPACE}|" "${COMPDB_FILE}"  # Replace workspace_root marker
 rm "${COMPDB_FILE}.bak"
 echo "]" >> "${COMPDB_FILE}"
 

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -28,6 +28,6 @@ load("@compdb//:aspects.bzl", "compilation_database")
 
 compilation_database(
     name = "compdb",
-    exec_root_marker = False,
+    remove_workspace_root_marker = True,
     targets = ["B"],
 )


### PR DESCRIPTION
Hi,

thank you so much for explicitly specifying the cc rules. That fixed an error, triggered if a BUILD file does not contain any targets with srcs attribute. I'm now able to use both methods to create the compilation database, `generate.sh` and calling the bazel compilation_database() to generate the json file for a specific target.

I tweaked a little bit around to get my setup to work with the script `generate.sh` which now generates an absolute path to the sources under `<workspace_root>/bazel-<workspace-name>`. If I got it right, then using the workspace_root is more reliable than exec_root as the latter is somewhere in /tmp and could change/removed e.g. when bazel server is restarted. That would invalidate the compilation database and require a new run to create the compilation database and feed this into the IDE; even if no source has changed. The workspace_root however will be always the same. In summary I implemented the following logic:

1.  generate.sh creates the `compile_commands.json` in the bazel-compdb submodule tree. It contains already the **absolute path** to the workspace_root/baze-<workspace-name>. This file loads successfully with rtags without any additional args.
2. calling the `compilation_database` rule creates the `compile_commands.json` in `workspace_root/bazel-bin`. This one contains a **relative path** to the source files. This works quite well with rtags by specifying the project root using rc's `--project_root` arg (see my rtags previous patch). The marker, now `__WORKSPACE_ROOT__`, is not included by default. However, one could explicitly keep it by specifying `remove_workspace_root_marker = False,` as outlined in the documentation.

As this change works for both, absolute and relative paths out-of-the-box it would be nice if you could give it a try and see if it works for you as well. I would appreciate if you could that PR to your implementation.

Thank you so much for sharing!