### PR TITLE
Export RELEASE_VERSION for the rest commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ the `generate.sh` script.  This will create a `compile_commands.json` file at
 your workspace root. For example,
 
 ```sh
-RELEASE_VERSION=0.1
+export RELEASE_VERSION=0.1
 curl -L https://github.com/grailbio/bazel-compilation-database/archive/${RELEASE_VERSION}.tar.gz | tar -xz
 bazel-compilation-database-${RELEASE_VERSION}/generate.sh
 ```


### PR DESCRIPTION
Exporting RELEASE_VERSION makes it available in the rest commands.