### PR TITLE
adding compile_flags to aspect_impl

### DIFF
--- a/aspects.bzl
+++ b/aspects.bzl
@@ -69,6 +69,7 @@ def _compilation_database_aspect_impl(target, ctx):
         return []
 
     compilation_db = []
+    compile_flags = []
 
     cc_toolchain = find_cpp_toolchain(ctx)
     feature_configuration = cc_common.configure_features(
@@ -118,6 +119,7 @@ def _compilation_database_aspect_impl(target, ctx):
 
     compile_flags = (compiler_options +
                      target.cc.compile_flags +
+                     compile_flags + # to capture the macosx case
                      (ctx.rule.attr.copts if "copts" in dir(ctx.rule.attr) else []))
     # system built-in directories (helpful for macOS).
     if cc_toolchain.libc == "macosx":


### PR DESCRIPTION
The most recent version of the `aspects.bzl` file throws an error about `compile_flags` being undefined at line 98 on my OSX machine. By changing these two lines, I got it to run and got the expected output.