### PR TITLE
Make it usable via vim-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ the `generate.sh` script.  This will create a `compile_commands.json` file at
 your workspace root. For example,
 
 ```sh
-RELEASE_VERSION=0.3.2
+RELEASE_VERSION=0.3.3
 curl -L https://github.com/grailbio/bazel-compilation-database/archive/${RELEASE_VERSION}.tar.gz | tar -xz
 bazel-compilation-database-${RELEASE_VERSION}/generate.sh
 ```
@@ -44,6 +44,7 @@ compilation_database(
 
 ycmd
 ----
+
 If you want to use this project solely for semantic auto completion using
 [ycmd][ycm] (YouCompleteMe) based editor plugins, then the recommended approach
 is to set your extra conf script to the bundled .ycm_extra_conf.py. With this,
@@ -51,20 +52,21 @@ you don't have to maintain a separate compile_commands.json file through a
 script and/or a `compilation_database` target. Compile commands are fetched
 from bazel as the files are opened in your editor.
 
-Follow the instructions as above for making the files available in this repo
-somewhere in the workspace, and then configure vim to use the
-`.ycm_extra_conf.py` script that you just extracted. One way is to make a
-symlink to the py script from the top of your workspace root. Another way is to
-set the `ycm_global_ycm_extra_conf` variable in vim.
-
-vim-plugin
----------
-To include everything as a vim plugin you can install this repo with your favourite
-plugin manager. It sets `g:ycm_global_ycm_extra_conf` and instruments bazel with the correct paths.
+The easiest way to set up this project for use by YouCompleteMe is to install
+this project as a vim plugin with your favourite plugin manager.  The plugin
+will sets `g:ycm_global_ycm_extra_conf` and instruments bazel with the correct
+paths.
 e.g. Plugged
 ```
 PlugInstall grailbio/bazel-compilation-database
 ```
+
+An alternative approach is to follow the instructions as above for making the
+files available in this repo somewhere in the workspace, and then configure vim
+to use the `.ycm_extra_conf.py` script that you just extracted. One way is to
+make a symlink to the py script from the top of your workspace root. Another
+way is to set the `ycm_global_ycm_extra_conf` variable in vim.
+
 
 Contributing
 ------------

--- a/README.md
+++ b/README.md
@@ -57,6 +57,15 @@ somewhere in the workspace, and then configure vim to use the
 symlink to the py script from the top of your workspace root. Another way is to
 set the `ycm_global_ycm_extra_conf` variable in vim.
 
+vim-plugin
+---------
+To include everything as a vim plugin you can install this repo with your favourite
+plugin manager. It sets `g:ycm_global_ycm_extra_conf` and instruments bazel with the correct paths.
+e.g. Plugged
+```
+PlugInstall grailbio/bazel-compilation-database
+```
+
 Contributing
 ------------
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,1 @@
+workspace(name = "bazel_compdb")

--- a/plugin/bazel-compilation-database.vim
+++ b/plugin/bazel-compilation-database.vim
@@ -1,0 +1,1 @@
+let g:ycm_global_ycm_extra_conf = expand("<sfile>:p:h:h") . "/.ycm_extra_conf.py"

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -7,8 +7,4 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 bazel build :compdb
 diff expected_file.json bazel-bin/compile_commands.json
 
-ln -s ../aspects.bzl .
-cp ../.ycm_extra_conf.py .
-diff expected_ycm_output.json <(python .ycm_extra_conf.py a.cc)
-rm ./.ycm_extra_conf.py
-rm ./aspects.bzl
+diff expected_ycm_output.json <(python ../.ycm_extra_conf.py a.cc)


### PR DESCRIPTION
I wanted to have less manual steps when using this great tool.
I added a very basic vim plugin which sets the ycm extra conf global to use the configuration.

In my case bazel complained about the relative paths and didn't run.
I resolved this by referring to it via an external package which is also set via the command line.

In general the tool would be then usable just by installing it as a vim plugin.

I hope this fits in the overall idea of how the tool is intended to be used.