### PR TITLE
python3 compatible print statement

### DIFF
--- a/.ycm_extra_conf.py
+++ b/.ycm_extra_conf.py
@@ -1,7 +1,5 @@
 #!/usr/bin/python
 
-from __future__ import print_function
-
 # Copyright 2018 GRAIL, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,6 +24,8 @@ repository.
 For Option 2 (.ycm_extra_conf.py), symlink this file to the root of your
 workspace and bazel's output_base, or set it as your global config.
 """
+
+from __future__ import print_function
 
 import json
 import os

--- a/.ycm_extra_conf.py
+++ b/.ycm_extra_conf.py
@@ -1,5 +1,7 @@
 #!/usr/bin/python
 
+from __future__ import print_function
+
 # Copyright 2018 GRAIL, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -196,4 +198,4 @@ def FlagsForFile(filename, **kwargs):
 # For testing; needs exactly one argument as path of file.
 if __name__ == '__main__':
     filename = os.path.abspath(sys.argv[1])
-    print FlagsForFile(filename)
+    print(FlagsForFile(filename))


### PR DESCRIPTION
Python2 style print statement causes a syntax error when running under python3. (YCM is running under python3 on my machine)