### PR TITLE
Empty sources not reason to exit early

### DIFF
--- a/aspects.bzl
+++ b/aspects.bzl
@@ -259,8 +259,6 @@ def _compilation_database_aspect_impl(target, ctx):
     )
 
     srcs = _sources(target, ctx)
-    if not srcs:
-        return []
 
     compiler_info = None
 


### PR DESCRIPTION
When a target has no sources, it may still have transitive dependencies, so should return a provider populated with an empty compilation_db and its transitive dependencies.