### PR TITLE
Use Settings instead of FlagsForFile

### DIFF
--- a/.ycm_extra_conf.py
+++ b/.ycm_extra_conf.py
@@ -150,9 +150,9 @@ def standardize_flags(flags, bazel_workspace):
     return flags
 
 #pylint: disable=W0613,C0103
-def Settings(filename, **kwargs):
-    """Function that is called by YCM expecting a dict with at least a 'flags'
-    key that points to an array of strings as flags.
+def cfamily_settings(filename, **kwargs):
+    """C-family settings as a dict with at least a 'flags' key that points to
+    an array of strings as flags.
     """
 
     bazel_info_dict = bazel_info()
@@ -216,7 +216,15 @@ def Settings(filename, **kwargs):
         'include_paths_relative_to_dir': bazel_exec_root,
         }
 
+def Settings(**kwargs):
+    """Function that is called by YCM with language and filename arguments,
+    and expects a dict of language-specific settings.
+    """
+    if kwargs['language'] == 'cfamily':
+        cfamily_settings(kwargs['filename'], **kwargs)
+    return {}
+
 # For testing; needs exactly one argument as path of file.
 if __name__ == '__main__':
     filename = os.path.abspath(sys.argv[1])
-    print(Settings(filename))
+    print(cfamily_settings(filename))

--- a/.ycm_extra_conf.py
+++ b/.ycm_extra_conf.py
@@ -150,7 +150,7 @@ def standardize_flags(flags, bazel_workspace):
     return flags
 
 #pylint: disable=W0613,C0103
-def FlagsForFile(filename, **kwargs):
+def Settings(filename, **kwargs):
     """Function that is called by YCM expecting a dict with at least a 'flags'
     key that points to an array of strings as flags.
     """
@@ -219,4 +219,4 @@ def FlagsForFile(filename, **kwargs):
 # For testing; needs exactly one argument as path of file.
 if __name__ == '__main__':
     filename = os.path.abspath(sys.argv[1])
-    print(FlagsForFile(filename))
+    print(Settings(filename))


### PR DESCRIPTION
ycmd has migrated to using Settings instead of FlagsForFile in this
change: https://github.com/ycm-core/ycmd/commit/66030cd94299114ae316796f3cad181cac8a007c#diff-04c6e90faac2675aa89e2176d2eec7d8R215