### PR TITLE
Add support for reading BAZEL env var

### DIFF
--- a/.ycm_extra_conf.py
+++ b/.ycm_extra_conf.py
@@ -36,12 +36,15 @@ import sys
 import xml.etree.ElementTree as ElementTree
 
 
+_BAZEL = os.getenv("BAZEL_COMPDB_BAZEL_PATH") or "bazel"
+
+
 def bazel_info():
     """Returns a dict containing key values from bazel info."""
 
     bazel_info_dict = dict()
     try:
-        out = subprocess.check_output(['bazel', 'info']).decode('utf-8').strip().split('\n')
+        out = subprocess.check_output([_BAZEL, 'info']).decode('utf-8').strip().split('\n')
     except subprocess.CalledProcessError as err:
         # This exit code is returned when this command is run outside of a bazel workspace.
         if err.returncode == 2:
@@ -57,7 +60,7 @@ def bazel_query(args):
     """Executes bazel query with the given args and returns the output."""
 
     # TODO: switch to cquery when it supports siblings and less crash-y with external repos.
-    query_cmd = ['bazel', 'query'] + args
+    query_cmd = [_BAZEL, 'query'] + args
     proc = subprocess.Popen(query_cmd, stdout=subprocess.PIPE)
     return proc.communicate()[0].decode('utf-8')
 
@@ -189,7 +192,7 @@ def cfamily_settings(filename):
     aspect_definition = '--aspects=@bazel_compdb//:aspects.bzl%compilation_database_aspect'
 
     bazel_aspects = [
-        'bazel',
+        _BAZEL,
         'build',
         aspect_definition,
         repository_override,

--- a/generate.sh
+++ b/generate.sh
@@ -81,13 +81,14 @@ function get_realpath() {
 
 readonly ASPECTS_DIR="$(dirname "$(get_realpath "${BASH_SOURCE[0]}")")"
 readonly OUTPUT_GROUPS="compdb_files"
+readonly BAZEL="${BAZEL_COMPDB_BAZEL_PATH:-bazel}"
 
-readonly WORKSPACE="$(bazel info workspace)"
-readonly EXEC_ROOT="$(bazel info execution_root)"
+readonly WORKSPACE="$("$BAZEL" info workspace)"
+readonly EXEC_ROOT="$("$BAZEL" info execution_root)"
 readonly COMPDB_FILE="${WORKSPACE}/compile_commands.json"
 
 readonly QUERY_CMD=(
-  bazel query
+  "$BAZEL" query
     --noshow_progress
     --noshow_loading_progress
     'kind("cc_(library|binary|test|inc_library|proto_library)", //...) union kind("objc_(library|binary|test)", //...)'
@@ -99,7 +100,7 @@ if [[ -e "${EXEC_ROOT}" ]]; then
 fi
 
 # shellcheck disable=SC2046
-bazel build \
+"$BAZEL" build \
   "--override_repository=bazel_compdb=${ASPECTS_DIR}" \
   "--aspects=@bazel_compdb//:aspects.bzl%compilation_database_aspect" \
   "--noshow_progress" \


### PR DESCRIPTION
For some use cases it's nice to be able to pass a non-default bazel as
the executable used for this query. This reads the BAZEL environment
variable to do that, and falls back to the previously default if it
doesn't exist.