### PR TITLE
Properly handle defines with space

### DIFF
--- a/aspects.bzl
+++ b/aspects.bzl
@@ -87,7 +87,7 @@ def get_compile_flags(dep):
     options = []
     compilation_context = dep[CcInfo].compilation_context
     for define in compilation_context.defines.to_list():
-        options.append("-D{}".format(define))
+        options.append("-D\"{}\"".format(define))
 
     for system_include in compilation_context.system_includes.to_list():
         if len(system_include) == 0:
@@ -200,7 +200,7 @@ def _objc_compiler_info(ctx, target, srcs, feature_configuration, cc_toolchain):
         ),
     )
 
-    defines = ["-D{}".format(val) for val in target.objc.define.to_list()]
+    defines = ["-D\"{}\"".format(val) for val in target.objc.define.to_list()]
     includes = ["-I{}".format(val) for val in target.objc.include.to_list()]
     system_includes = ["-isystem {}".format(val) for val in target.objc.include_system.to_list()]
     iquotes = ["-iquote {}".format(val) for val in target.objc.iquote.to_list()]


### PR DESCRIPTION
If there's a target with a define that has a space in it such as:

```
cc_binary(
    name="dummy",
    srcs=["dummy.cpp"],
    defines=["A_STRING='foo bar'"]
)
```

The generated compilation DB looks like so which cause compilation error
```
{
    "command": "clang -D_FORTIFY_SOURCE=1 [......] -DA_STRING=foo bar [....] dummy.cpp",
    "directory": "/some/project/path",
    "file": "dummy.cpp"
},
```

This PR simply escape defines so it looks like so`-D"A_STRING=foo bar"`. There may be more case where such workaround is needed (for instance any path with spaces in it)