### PR TITLE
Handle targets with no compilation commands

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -110,7 +110,7 @@ fi
   $("${QUERY_CMD[@]}") > /dev/null
 
 echo "[" > "${COMPDB_FILE}"
-find "${EXEC_ROOT}" -name '*.compile_commands.json' -exec bash -c 'cat "$1" && echo ,' _ {} \; \
+find "${EXEC_ROOT}" -name '*.compile_commands.json' -not -empty -exec bash -c 'cat "$1" && echo ,' _ {} \; \
   >> "${COMPDB_FILE}"
 echo "]" >> "${COMPDB_FILE}"
 

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -27,6 +27,11 @@ cc_library(
     deps = [":a"],
 )
 
+cc_library(
+    name = "b_forward",
+    deps = [":b"],
+)
+
 cc_binary(
     name = "stdlib",
     srcs = ["stdlib.cc"],


### PR DESCRIPTION
They used to produce invalid JSON.