### PR TITLE
Assume that header-only libraries are C++

### DIFF
--- a/aspects.bzl
+++ b/aspects.bzl
@@ -34,6 +34,7 @@ load(
 CompilationAspect = provider()
 
 _cpp_header_extensions = [
+    "hh",
     "hxx",
     "ipp",
     "hpp",

--- a/aspects.bzl
+++ b/aspects.bzl
@@ -33,11 +33,19 @@ load(
 
 CompilationAspect = provider()
 
+_cpp_header_extensions = [
+    "hxx",
+    "ipp",
+    "hpp",
+]
+
+_c_or_cpp_header_extensions = ["h"] + _cpp_header_extensions
+
 _cpp_extensions = [
     "cc",
     "cpp",
     "cxx",
-]
+] + _cpp_header_extensions
 
 _cc_rules = [
     "cc_library",
@@ -61,6 +69,8 @@ def _compilation_db_json(compilation_db):
     return ",\n".join(entries)
 
 def _is_cpp_target(srcs):
+    if all([src.extension in _c_or_cpp_header_extensions for src in srcs]):
+        return True  # assume header-only lib is c++
     return any([src.extension in _cpp_extensions for src in srcs])
 
 def _is_objcpp_target(srcs):


### PR DESCRIPTION
As far as I know, it's unusual for pure-C libraries to be header-only, but
in C++ world it's fairly common. 

This PR also adds a few more C++ extensions, commonly used for C++ 
header files (.ipp is used by Boost). 