### PR TITLE
Use awk instead of cat&echo to boost json concating performance

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -110,7 +110,8 @@ fi
   $("${QUERY_CMD[@]}") > /dev/null
 
 echo "[" > "${COMPDB_FILE}"
-find "${EXEC_ROOT}" -name '*.compile_commands.json' -not -empty -exec bash -c 'cat "$1" && echo ,' _ {} \; \
+find "${EXEC_ROOT}" -name '*.compile_commands.json' -not -empty \
+    | awk '{fn=$0; RS="^$"; getline s<fn; close(fn); RS="\n"; print s "," }' \
   >> "${COMPDB_FILE}"
 echo "]" >> "${COMPDB_FILE}"
 


### PR DESCRIPTION
```
$ find . -name '*.compile_commands.json' -not -empty | wc -l
3513


$ time find . -name '*.compile_commands.json' -not -empty | awk '{fn=$0; RS="^$"; getline s<fn; close(fn); RS="\n"; print s "," }' > new.txt

________________________________________________________
Executed in  684.10 millis    fish           external 
   usr time   49.34 millis    1.37 millis   47.97 millis 
   sys time  694.53 millis    9.29 millis  685.24 millis 


$ time find . -name '*.compile_commands.json' -not -empty -exec bash -c 'cat "$1" && echo ,' _ '{}' \; > old.txt

________________________________________________________
Executed in  125.99 secs   fish           external 
   usr time    8.55 secs    0.53 millis    8.55 secs 
   sys time   22.22 secs    8.63 millis   22.21 secs '


$ diff new.txt old.txt
```