### PR TITLE
Also collect source files from non_arc_srcs attributes

### DIFF
--- a/aspects.bzl
+++ b/aspects.bzl
@@ -87,6 +87,8 @@ def _sources(target, ctx):
         srcs += [f for src in ctx.rule.attr.srcs for f in src.files.to_list()]
     if "hdrs" in dir(ctx.rule.attr):
         srcs += [f for src in ctx.rule.attr.hdrs for f in src.files.to_list()]
+    if "non_arc_srcs" in dir(ctx.rule.attr):
+        srcs += [f for src in ctx.rule.attr.non_arc_srcs for f in src.files.to_list()]
 
     if ctx.rule.kind == "cc_proto_library":
         srcs += [f for f in target.files.to_list() if f.extension in ["h", "cc"]]

--- a/aspects.bzl
+++ b/aspects.bzl
@@ -117,6 +117,9 @@ def get_compile_flags(dep):
             quote_include = "."
         options.append("-iquote {}".format(quote_include))
 
+    for framework_include in compilation_context.framework_includes.to_list():
+        options.append("-F\"{}\"".format(framework_include))
+
     return options
 
 def _cc_compiler_info(ctx, target, srcs, feature_configuration, cc_toolchain):
@@ -213,13 +216,8 @@ def _objc_compiler_info(ctx, target, srcs, feature_configuration, cc_toolchain):
         ),
     )
 
-    defines = ["-D\"{}\"".format(val) for val in target.objc.define.to_list()]
-    includes = ["-I{}".format(val) for val in target.objc.include.to_list()]
-    system_includes = ["-isystem {}".format(val) for val in target.objc.include_system.to_list()]
-    iquotes = ["-iquote {}".format(val) for val in target.objc.iquote.to_list()]
     frameworks = (["-F {}/..".format(val) for val in target.objc.static_framework_paths.to_list()] +
-                  ["-F {}/..".format(val) for val in target.objc.dynamic_framework_paths.to_list()] +
-                  ["-F {}/..".format(val) for val in target.objc.framework_search_path_only.to_list()])
+                  ["-F {}/..".format(val) for val in target.objc.dynamic_framework_paths.to_list()])
 
     xcode_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig]
 
@@ -238,10 +236,6 @@ def _objc_compiler_info(ctx, target, srcs, feature_configuration, cc_toolchain):
                      ["-F {}/Developer/Library/Frameworks".format(platform_root)] +
                      # FIXME this needs to be done per-file to be fully correct
                      ["-fobjc-arc"] +
-                     defines +
-                     includes +
-                     iquotes +
-                     system_includes +
                      frameworks +
                      (ctx.rule.attr.copts if "copts" in dir(ctx.rule.attr) else []))
 


### PR DESCRIPTION
Our code is using the `obc_library()` rule along with the `non_arc_srcs` attributes which aren't collected as sources files by `bazel-compilation-database`. This PR simply add the sources files in `non_arc_srcs` to the list of sources files to process by the compilation db script.

**Note**: This is partially working as while non ARC files are collected they are still compiled with `-fobjc-arc` here https://github.com/grailbio/bazel-compilation-database/blob/master/aspects.bzl#L237-L238 . Any idea what would be the best way to handle that?