### PR TITLE
Fix bazel query label

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -91,6 +91,7 @@ readonly QUERY_CMD=(
   "$BAZEL" query
     --noshow_progress
     --noshow_loading_progress
+    --output label
     'kind("cc_(library|binary|test|inc_library|proto_library)", //...) union kind("objc_(library|binary|test)", //...)'
 )
 


### PR DESCRIPTION
In bazel 4.0.0, the current bazel query command gives output such as:
```
cc_binary rule //main:hellow_world
```
This cound not be consumed by the following command in bazel build. 
So the change here is to add a `--output label` as the output format.