### PR TITLE
Enable passing options to Bazel when calling generate.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,13 @@ VERSION="0.4.5"
 
 bazel-compdb # This will generate compile_commands.json in your workspace root.
 
+# To pass additional flags to bazel, pass the flags as arguments after --
+bazel-compdb -- [additional flags for bazel]
+
 # You can tweak some behavior with flags:
 # 1. To use the source dir instead of bazel-execroot for directory in which clang commands are run.
 bazel-compdb -s
+bazel-compdb -s -- [additional flags for bazel]
 ```
 
 ### Selected targets

--- a/generate.sh
+++ b/generate.sh
@@ -37,6 +37,7 @@ while getopts "sh" opt; do
     *) >&2 echo "invalid option ${opt}"; exit 1;;
   esac
 done
+shift $((OPTIND-1))
 
 # This function is copied from https://source.bazel.build/bazel/+/master:scripts/packages/bazel.sh.
 # `readlink -f` that works on OSX too.


### PR DESCRIPTION
My use case requires me to pass some special options when calling `bazel build`.

It looks like this used to be supported by using `$@` but it has since stopped working with the addition of the getopts code.

This PR enables this behaviour again with the addition of a new `-o <string>` option for generate.sh.

For example, to change the C++ version 
```
./generate.sh -o '--cxxopt="-std=c++17"'
```