### PR TITLE
Match target kind from the start of the string

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -92,7 +92,7 @@ readonly QUERY_CMD=(
   "$BAZEL" query
     --noshow_progress
     --noshow_loading_progress
-    'kind("cc_(library|binary|test|inc_library|proto_library)", //...) union kind("objc_(library|binary|test)", //...)'
+    'kind("^cc_(library|binary|test|inc_library|proto_library)", //...) union kind("^objc_(library|binary|test)", //...)'
 )
 
 # Clean any previously generated files.


### PR DESCRIPTION
In my project I use [emsdk](https://github.com/emscripten-core/emsdk/tree/main/bazel) and have `wasm_cc_binary` targets. These targets don't build with the standard config, thus when bazel-compdb matches against them it fails. The easy fix is to just change the pattern so that it requires `cc_` or `objc_` to be at the start of the string.