### PR TITLE
Add alternative implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ give you write access.
 
 #### Alternative/Derived implementations:
 
+- https://github.com/hedronvision/bazel-compile-commands-extractor
+  - Uses an alternate approach based on aquery. This directly asks Bazel for its exact build commands, while still being fast and not requiring a full build. Avoids whole categories of issues.
 - https://github.com/stackb/bazel-stack-vscode-cc
 
 ====


### PR DESCRIPTION
@siddharthab, I really appreciate all you've built here over the years. We loved using it and are sad to see it's now in maintenance mode. You were the first recommendation people pointed us to when we migrated to Bazel. Thank you for all you've done! 

For our projects that involved platform configuration and Bazel's compiler wrappers (like in #57) we'd initially started experimenting with action_listeners (like Kythe; slow, requiring a full build), after noticing some limiting problems with the aspect-based approach. We then noticed that we could get something orders of magnitude faster and equally accurate by directly asking bazel for its compile commands using aquery, and then doing some subsequent "debazeling" to let clang tooling understand it.

The efforts to fix those issues led to https://github.com/hedronvision/bazel-compile-commands-extractor, which we've just released publicly after seeing that you were moving this repo into maintenance mode. (Also because lots of people continued requesting that we release it.)

Anyway, we'd be honored if you'd consider adding us to your list of alternatives. The effort was certainly inspired by yours, and I think the aquery approach is great one if you're ready to move on and pass the torch.

Thanks for your consideration,
Chris

P.S. Also, congratulations on all the great stuff you all have built at Grail--and on the IPO-turned-acquisition. It's been fun to get to watch from the sidelines.