### PR TITLE
Add possibility to provide flags that would be executed with any Bazel command

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ bazel-compdb -s -- [additional flags for bazel]
 # 2. To consider only targets given by a specific query pattern, say `//cc/...`. Also see below section for another way.
 bazel-compdb -q //cc/...
 bazel-compdb -q //cc/... -- [additional flags for bazel]
+# 3. To pass arguments that you want to execute on every bazel command use -r flag if argument contain at the beginning of it
+# use -r=<argument> to pass each new argument passed that way would append list of previous
+bazel-compdb -r=--first -r=--second
+bazel-compdb -r=--first -r=--second -- [additional flags for bazel]
 ```
 
 ### Selected targets


### PR DESCRIPTION
I was working on my project in vscode and found out your plugin to improve IntelliSense in it, but while was trying to build found out that your extension for bazel don't have possibility to pass required flags such as `--experimental_repo_remote_exec` I need it in every bazel command because my project uses TensorFlow and I want to provide my solution of this problem also I like to make this extension more flexible and don't have to load manually aspects.bzl we can take it from @com_grail_bazel_compdb and just make a rule to name package this way or parse name of package somehow.
But about required arguments I think that it is very useful feature.
Also I have some more suggestions to improve compatibility with vscode