### PR TITLE
use unlink to delete for pathlib paths

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -90,7 +90,7 @@ if __name__ == "__main__":
 
     # Clean any previously generated files.
     for db in pathlib.Path(bazel_exec_root).glob('**/*.compile_commands.json'):
-        os.remove(db)
+        db.unlink()
 
     build_args = [
         '--override_repository=bazel_compdb={}'.format(aspects_dir),


### PR DESCRIPTION
db here is a PosixPath type so it doesn't play nicely with os.remove(). I was getting the following error:
`TypeError: remove: illegal type for path parameter`
Using the pathlib builtin `unlink()` resolve the issue though.