### PR TITLE
Added sys import in generate.py

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -26,6 +26,7 @@ import json
 import os
 import pathlib
 import subprocess
+import sys
 import tempfile
 
 


### PR DESCRIPTION
This is a fairly minor PR. While using the repo to generate a compilation database, I accidentally triggered the sys exit logic, and got a `NameError` since `sys` wasn't imported.