### PR TITLE
Ignore incompatible targets

### DIFF
--- a/aspects.bzl
+++ b/aspects.bzl
@@ -287,8 +287,9 @@ def _compilation_database_aspect_impl(target, ctx):
         all_compdb_files.append(dep[OutputGroupInfo].compdb_files)
         all_header_files.append(dep[OutputGroupInfo].header_files)
 
+    # TODO: Remove CcInfo check once https://github.com/bazelbuild/bazel/pull/15426 is released
     # We support only these rule kinds.
-    if ctx.rule.kind not in _all_rules:
+    if ctx.rule.kind not in _all_rules or CcInfo not in target:
         return [
             CompilationAspect(compilation_db = depset(transitive = transitive_compilation_db)),
             OutputGroupInfo(


### PR DESCRIPTION
Currently incompatible targets are included by the aspect until the
linked PR lands. In this case the targets don't have CcInfo, so we can
use that as a workaround for ignoring them for now.