### PR TITLE
Disable module maps feature since it is not supported by the toolchain

### DIFF
--- a/aspects.bzl
+++ b/aspects.bzl
@@ -63,6 +63,11 @@ _objc_rules = [
 
 _all_rules = _cc_rules + _objc_rules
 
+# Disable features not supported by the toolchain
+DISABLED_FEATURES = [
+    "module_maps",
+]
+
 def _is_cpp_target(srcs):
     if all([src.extension in _c_or_cpp_header_extensions for src in srcs]):
         return True  # assume header-only lib is c++
@@ -306,7 +311,7 @@ def _compilation_database_aspect_impl(target, ctx):
         ctx = ctx,
         cc_toolchain = cc_toolchain,
         requested_features = ctx.features,
-        unsupported_features = ctx.disabled_features,
+        unsupported_features = ctx.disabled_features + DISABLED_FEATURES,
     )
 
     if ctx.rule.kind in _cc_rules:


### PR DESCRIPTION
Fix for https://github.com/grailbio/bazel-compilation-database/issues/101

See https://github.com/bazelbuild/rules_cc/blob/2f8c04c04462ab83c545ab14c0da68c3b4c96191/examples/my_c_compile/my_c_compile.bzl for instance.

I haven't found what this feature actually does or whether it is an issue not to support it.  
They do that in the CC example, so I would assume it is for other languages than C/C++?