### PR TITLE
Feat(tools): support windows platform

### DIFF
--- a/tools.bzl
+++ b/tools.bzl
@@ -13,12 +13,20 @@
 # limitations under the License.
 
 def _bazel_output_base_util_impl(rctx):
-    res = rctx.execute(["pwd"])
+    if rctx.os.name.lower().startswith("windows") == True:
+        res = rctx.execute(["cmd", "/c", "echo", "%cd%"])
+    else:
+        res = rctx.execute(["pwd"])
+
     if res.return_code != 0:
         fail("getting output base failed (%d): %s" % (res.return_code, res.stderr))
 
     # Strip last two path components.
-    path_components = res.stdout.rstrip("\n").split("/")[:-2]
+    if rctx.os.name.lower().startswith("windows") == True:
+        path_components = res.stdout.rstrip("\n").split("\\")[:-2]
+    else:
+        path_components = res.stdout.rstrip("\n").split("/")[:-2]
+
     output_base = "/".join(path_components)
 
     rctx.file("BUILD.bazel", "")


### PR DESCRIPTION
Hi,

I tried to use `bazel-compilation-database` on windows and found some problems. In general, windows do not have `pwd` by default. So I use `cmd /c echo %cd%` instead.

Also, the parsing of paths requires a little change.